### PR TITLE
Add ability to add attachments to transactional mails (fixes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Just `pip install listmonk`
 
 ```python
 
+import pathlib
 import listmonk
+
 listmonk.set_url_base('https://yourlistmonkurl.com')
 
 listmonk.login('sammy_z', '1234')
@@ -82,6 +84,21 @@ template_data = {'full_name': 'Test User', 'reset_code': 'abc123'}
 status: bool = listmonk.send_transactional_email(
                      to_email, template_id, from_email=from_email, 
                      template_data=template_data, content_type='html')
+
+# You can also add one or multiple attachments with transactional mails
+attachments = [
+    pathlib.Path("/path/to/your/file1.pdf"),
+    pathlib.Path("/path/to/your/file2.png")
+]
+
+status: bool = listmonk.send_transactional_email(
+    to_email,
+    template_id,
+    from_email=from_email,
+    template_data=template_data,
+    attachments=attachments,
+    content_type='html'
+)
 ```
 
 ## Want to contribute?

--- a/listmonk/errors/__init__.py
+++ b/listmonk/errors/__init__.py
@@ -4,3 +4,6 @@ class ValidationError(Exception):
 
 class OperationNotAllowedError(ValidationError):
     pass
+
+class FileNotFoundError(ValidationError):
+    pass


### PR DESCRIPTION
This PR introduces the option to add attachments to transactional mails as discussed in #5 . 

One or multiple attachments can be added as new optional parameter to the existing method.

There's one thing I'm not too happy about, but didn't want to change it: The global `core_headers` currently sets the content type to `application/json` which is not applicable to this particular request. For now, I'm creating a copy to not modify the original dict and remove the offending entry. That's not beautiful, but I couldn't think of an easier way without refactoring the code.