### PR TITLE
fix: can't create campaign because headers is a dictionary

### DIFF
--- a/listmonk/impl/__init__.py
+++ b/listmonk/impl/__init__.py
@@ -1090,7 +1090,7 @@ def create_campaign(
         ValueError: If required parameters (name, subject, from_email) are not provided.
     """
     if headers is None:
-        headers = {}
+        headers = []
     if tags is None:
         tags = []
 

--- a/listmonk/models/__init__.py
+++ b/listmonk/models/__init__.py
@@ -83,7 +83,7 @@ class Campaign(BaseModel):
     tags: list[str] = pydantic.Field(default_factory=list)
     template_id: int
     messenger: Optional[str] = None
-    headers: dict[str, Optional[str]] = pydantic.Field(default_factory=dict)
+    headers: list[dict[str, Optional[str]]] = pydantic.Field(default_factory=list)
 
 
 class CreateCampaignModel(BaseModel):
@@ -99,7 +99,7 @@ class CreateCampaignModel(BaseModel):
     messenger: Optional[str] = None
     template_id: Optional[int]
     tags: list[str] = pydantic.Field(default_factory=list)
-    headers: dict[str, Optional[str]] = pydantic.Field(default_factory=dict)
+    headers: list[dict[str, Optional[str]]] = pydantic.Field(default_factory=list)
 
     @field_serializer('send_at')
     def serialize_date_times(self, fld: datetime.datetime, _info: Any) -> Optional[str]:


### PR DESCRIPTION
Trying to create a campaign with a listmonk server 6.0.0 throws a 400 error because the API expects `headers` as a list of dictionaries not just a dictionary.
This is what I had to do, to get it to work. I think if you want to set headers, that's broken now. Can someone else take a look at this? Maybe @pastorhudson is still around, since he implemented campaign support in the first place?