### PR TITLE
feat(send_transactional_email): add support for altbody

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ status: bool = listmonk.send_transactional_email(
     to_email, template_id, from_email=from_email,
     template_data=template_data, content_type='html')
 
+# Optional plaintext fallback for multipart HTML emails.
+status = listmonk.send_transactional_email(
+    to_email,
+    template_id,
+    from_email=from_email,
+    template_data=template_data,
+    content_type='html',
+    altbody='Plaintext order summary for mail clients that prefer text.'
+)
+
 # You can also add one or multiple attachments with transactional mails
 attachments = [
     pathlib.Path("/path/to/your/file1.pdf"),
@@ -103,7 +113,8 @@ status: bool = listmonk.send_transactional_email(
     from_email=from_email,
     template_data=template_data,
     attachments=attachments,
-    content_type='html'
+    content_type='html',
+    altbody='Plaintext fallback body'
 )
 
 # Access existing campaigns

--- a/change-log.md
+++ b/change-log.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* Add `altbody` support to `send_transactional_email()` for multipart HTML transactional emails
 
 ### Changed
 

--- a/example_client/client.py
+++ b/example_client/client.py
@@ -107,9 +107,15 @@ to_email = 'SUBSCRIBER_EMAIL_ON_YOUR_LIST'
 from_email = 'APPROVED_OUTBOUND_EMAIL_ON_DOMAIN'  # Optional
 template_id = 3  # *Transactional* template ID from your listmonk instance.
 template_data = {'order_id': 1772, 'shipping_date': 'Next week'}
+altbody = 'Your order 1772 ships next week.'
 if to_email != 'SUBSCRIBER_EMAIL_ON_YOUR_LIST':
     status = listmonk.send_transactional_email(
-        to_email, template_id, from_email=from_email, template_data=template_data, content_type='html'
+        to_email,
+        template_id,
+        from_email=from_email,
+        template_data=template_data,
+        content_type='html',
+        altbody=altbody,
     )
     print(f'Result of sending a tx email: {status}.', flush=True)
 else:

--- a/listmonk/impl/__init__.py
+++ b/listmonk/impl/__init__.py
@@ -734,6 +734,7 @@ def send_transactional_email(
     template_data: Optional[dict[str, Any]] = None,
     messenger_channel: str = 'email',
     content_type: str = 'markdown',
+    altbody: Optional[str] = None,
     attachments: Optional[list[Path]] = None,
     email_headers: Optional[list[dict[str, Optional[str]]]] = None,
     timeout_config: Optional[httpx.Timeout] = None,
@@ -747,6 +748,7 @@ def send_transactional_email(
         template_data: A dictionary of merge parameters for the template, available in the template as {{ .Tx.Data.* }}.
         messenger_channel: Default is "email", if you have SMS or some other channel, you can use it here.
         content_type: Email format options include html, markdown, and plain.
+        altbody: Optional alternate plaintext body for multipart HTML emails.
         attachments: Optional list of `pathlib.Path` objects pointing to file that will be sent as attachment.
         email_headers: Optional array of e-mail headers to include in all messages sent from this server. eg: [{"X-Custom": "value"}, {"X-Custom2": "value"}]
         timeout_config: Optional timeout configuration for the request. Default is 10 seconds.
@@ -778,6 +780,9 @@ def send_transactional_email(
 
     if from_email is not None:
         body_data['from_email'] = from_email
+
+    if altbody is not None:
+        body_data['altbody'] = altbody
 
     try:
         url = f'{url_base}{urls.send_tx}'


### PR DESCRIPTION
Now transactional api supports optional alternate plaintext body for multipart HTML emails (https://listmonk.app/docs/apis/transactional/#post-apitx).

This PR is adding `altbody` support to `send_transactional_email()` for multipart HTML transactional emails.